### PR TITLE
Add AddToPath note to conda packages

### DIFF
--- a/mambaforge/README.md
+++ b/mambaforge/README.md
@@ -5,15 +5,22 @@ Mambaforge installs the mamba package manager with the following features pre-co
   * [conda-forge](https://conda-forge.org/) set as the default (and only) channel.
   * Packages in the base environment are obtained from the [conda-forge channel](https://anaconda.org/conda-forge).
 
-You can provide parameters for the install ([conda docs](https://conda.io/projects/conda/en/latest/user-guide/install/windows.html#installing-in-silent-mode)). Example: `choco install mambaforge --params="'/AddToPath:1'"`.  
+You can provide parameters for the installation ([conda docs](https://conda.io/projects/conda/en/latest/user-guide/install/windows.html#installing-in-silent-mode)).  
 To have choco remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.
 
-  * /InstallationType:[AllUsers|JustMe]
-    * Default: AllUsers (install for all users)
-  * /RegisterPython:[0|1]
-    * Default: 1 (register mambaforge python as the system's default)
-  * /AddToPath:[0|1]
-    * Default: 0 (do not add mambaforge directories to path)
-  * /D:(installation path)
-    * Default-AllUsers: `$toolsDir\mambaforge` (`$toolsDir` is the path returned by `Get-ToolsLocation`) default is `C:\tools`
-    * Default-JustMe: `$Env:LOCALAPPDATA\mambaforge` (`$Env:LOCALAPPDATA` is set by Windows) default is `C:\Users\{USERNAME}\AppData\Local`
+  * `/InstallationType:`[`AllUsers`|`JustMe`]
+    * Default: `AllUsers` (install for all users)
+  * `/RegisterPython:`[`0`|`1`]
+    * Default: `1` (register mambaforge python as the system's default)
+  * `/AddToPath:`[`0`|`1`]
+    * Default: `0` (do not add mambaforge directories to path)
+    * _Note: As of Mambaforge 4.12.0-0, you cannot add mambaforge to the PATH environment during an `AllUsers` installation.  
+      This was done to address [a security exploit](https://nvd.nist.gov/vuln/detail/CVE-2022-26526) 
+      ([additional information](https://github.com/ContinuumIO/anaconda-issues/issues/12995#issuecomment-1188441961))._
+  * `/D:`(installation path)
+    * Default for `AllUsers`: `$toolsDir\mambaforge`  
+      (`$toolsDir` is the path returned by chocolatey's `Get-ToolsLocation` function and defaults to `C:\tools`)
+    * Default for `JustMe`: `$Env:LOCALAPPDATA\mambaforge`  
+      (`$Env:LOCALAPPDATA` is set by Windows and defaults to `C:\Users\{USERNAME}\AppData\Local`)
+
+Example: `choco install mambaforge --params="'/InstallationType:JustMe /AddToPath:1'"`.

--- a/miniforge3/README.md
+++ b/miniforge3/README.md
@@ -5,15 +5,22 @@ Miniforge3 installs the conda package manager with the following features pre-co
   * [conda-forge](https://conda-forge.org/) set as the default (and only) channel.
   * Packages in the base environment are obtained from the [conda-forge channel](https://anaconda.org/conda-forge).
 
-You can provide parameters for the install ([conda docs](https://conda.io/projects/conda/en/latest/user-guide/install/windows.html#installing-in-silent-mode)). Example: `choco install miniforge3 --params="'/AddToPath:1'"`.  
+You can provide parameters for the installation ([conda docs](https://conda.io/projects/conda/en/latest/user-guide/install/windows.html#installing-in-silent-mode)).  
 To have choco remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.
 
-  * /InstallationType:[AllUsers|JustMe]
-    * Default: AllUsers (install for all users)
-  * /RegisterPython:[0|1]
-    * Default: 1 (register miniforge3 python as the system's default)
-  * /AddToPath:[0|1]
-    * Default: 0 (do not add miniforge3 directories to path)
-  * /D:(installation path)
-    * Default-AllUsers: `$toolsDir\miniforge3` (`$toolsDir` is the path returned by `Get-ToolsLocation`) default is `C:\tools`
-    * Default-JustMe: `$Env:LOCALAPPDATA\miniforge3` (`$Env:LOCALAPPDATA` is set by Windows) default is `C:\Users\{USERNAME}\AppData\Local`
+  * `/InstallationType:`[`AllUsers`|`JustMe`]
+    * Default: `AllUsers` (install for all users)
+  * `/RegisterPython:`[`0`|`1`]
+    * Default: `1` (register miniforge3 python as the system's default)
+  * `/AddToPath:`[`0`|`1`]
+    * Default: `0` (do not add miniforge3 directories to path)
+    * _Note: As of Miniforge3 4.12.0-0, you cannot add miniforge3 to the PATH environment during an `AllUsers` installation.  
+      This was done to address [a security exploit](https://nvd.nist.gov/vuln/detail/CVE-2022-26526) 
+      ([additional information](https://github.com/ContinuumIO/anaconda-issues/issues/12995#issuecomment-1188441961))._
+  * `/D:`(installation path)
+    * Default for `AllUsers`: `$toolsDir\miniforge3`  
+      (`$toolsDir` is the path returned by chocolatey's `Get-ToolsLocation` function and defaults to `C:\tools`)
+    * Default for `JustMe`: `$Env:LOCALAPPDATA\miniforge3`  
+      (`$Env:LOCALAPPDATA` is set by Windows and defaults to `C:\Users\{USERNAME}\AppData\Local`)
+
+Example: `choco install miniforge3 --params="'/InstallationType:JustMe /AddToPath:1'"`.


### PR DESCRIPTION
This PR adds a note to the `mambaforge` and `miniforge3` packages, telling users that the `AddToPath` parameter does not work anymore, due to upstream reasons. It also refactors some of the README's writing.

Closes https://github.com/geicht/chocolatey-packages/issues/4