### PR TITLE
Update plugin installation and uninstallation paths to use the correct directory

### DIFF
--- a/docker-compose/tools/chocolateyInstall.ps1
+++ b/docker-compose/tools/chocolateyInstall.ps1
@@ -2,7 +2,7 @@
 $packageToolsDir        = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
 $executablePath         = Join-Path $packageToolsDir 'docker-compose.exe'
 
-$executableTargetDir    = 'C:\ProgramData\Docker\cli-plugins\'
+$executableTargetDir    = 'C:\Program Files\Docker\cli-plugins\'
 $executableTargetPath   = Join-Path $executableTargetDir 'docker-compose.exe'
 
 # create plugin directory if it doesn't exist
@@ -12,6 +12,19 @@ if (-not (Test-Path -Path $executableTargetDir)) {
 
 # remove docker-compose shim if it still exists
 Uninstall-BinFile -name docker-compose -ErrorAction:Ignore
+
+# clean up old installation location (backward compatibility)
+$oldExecutableDir  = 'C:\ProgramData\Docker\cli-plugins\'
+$oldExecutablePath = Join-Path $oldExecutableDir 'docker-compose.exe'
+if (Test-Path -Path $oldExecutablePath) {
+    Remove-Item -Path $oldExecutablePath -Force
+    # remove old directory if empty
+    if (Test-Path -Path $oldExecutableDir) {
+        if ($null -eq (Get-ChildItem -Path $oldExecutableDir)) {
+            Remove-Item -Path $oldExecutableDir -Force
+        }
+    }
+}
 
 # move executable
 Move-Item -Path $executablePath -Destination $executableTargetPath -Force

--- a/docker-compose/tools/chocolateyInstall.ps1
+++ b/docker-compose/tools/chocolateyInstall.ps1
@@ -16,13 +16,23 @@ Uninstall-BinFile -name docker-compose -ErrorAction:Ignore
 # clean up old installation location (backward compatibility)
 $oldExecutableDir  = 'C:\ProgramData\Docker\cli-plugins\'
 $oldExecutablePath = Join-Path $oldExecutableDir 'docker-compose.exe'
+$oldDockerPath     = Split-Path -Path $oldExecutableDir -Parent
+
 if (Test-Path -Path $oldExecutablePath) {
     Remove-Item -Path $oldExecutablePath -Force
-    # remove old directory if empty
-    if (Test-Path -Path $oldExecutableDir) {
-        if ($null -eq (Get-ChildItem -Path $oldExecutableDir)) {
-            Remove-Item -Path $oldExecutableDir -Force
-        }
+}
+
+# remove old plugin directory if empty
+if (Test-Path -Path $oldExecutableDir) {
+    if ($null -eq (Get-ChildItem -Path $oldExecutableDir)) {
+        Remove-Item -Path $oldExecutableDir -Force
+    }
+}
+
+# remove old docker directory if empty
+if (Test-Path -Path $oldDockerPath) {
+    if ($null -eq (Get-ChildItem -Path $oldDockerPath)) {
+        Remove-Item -Path $oldDockerPath -Force
     }
 }
 

--- a/docker-compose/tools/chocolateyUninstall.ps1
+++ b/docker-compose/tools/chocolateyUninstall.ps1
@@ -1,5 +1,5 @@
 ﻿$ErrorActionPreference = "Stop"
-$executableDir      = 'C:\ProgramData\Docker\cli-plugins\'
+$executableDir      = 'C:\Program Files\Docker\cli-plugins\'
 $executablePath     = Join-Path $executableDir 'docker-compose.exe'
 
 $dockerPath         = Split-Path -Path $executableDir -Parent


### PR DESCRIPTION
Due to https://github.com/docker/cli/pull/6713 the current installation path for `docker-compose` has been deprecated.